### PR TITLE
Remove unused pull-stream dependency

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -5,7 +5,6 @@ var isBuffer = Buffer.isBuffer
 var Obv = require('obv')
 var Append = require('append-batch')
 var createStreamCreator = require('pull-cursor')
-var Map = require('pull-stream/throughs/map')
 var Cache = require('hashlru')
 var Looper = require('pull-looper')
 


### PR DESCRIPTION
pull-stream is a devDependency, not a dependency, yet it was being require'd into inject.js. This is not a fundamentally important change, but good to have anyway.

(Tested locally that everything still works)