### PR TITLE
Add method to stream without cache

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -29,37 +29,31 @@ module.exports = function (blocks, frame, codec, file, cache) {
     })
   })
 
-  function getMeta (offset, cb) {
-    var data = cache.get(offset)
-    if (data) {
-      cb(null, data.value, data.prev, data.next)
-    }
-    else {
-      frame.getMeta(offset, function (err, value, prev, next) {
-        if(err) return cb(err)
-
-        var data = {
-          value: codec.decode(value),
-          prev: prev,
-          next: next
-        }
-
-        cache.set(offset, data)
+  function getMeta (offset, useCache, cb) {
+    if (useCache) {
+      var data = cache.get(offset)
+      if (data) {
         cb(null, data.value, data.prev, data.next)
-      })
+        return
+      }
     }
-  }
 
-  function getMetaNoCache (offset, cb) {
     frame.getMeta(offset, function (err, value, prev, next) {
       if(err) return cb(err)
 
-      cb(null, codec.decode(value), prev, next)
+      var data = {
+        value: codec.decode(value),
+        prev: prev,
+        next: next
+      }
+
+      if (useCache)
+        cache.set(offset, data)
+      cb(null, data.value, data.prev, data.next)
     })
   }
 
   var createStream = createStreamCreator(since, getMeta)
-  var createStreamNoCache = createStreamCreator(since, getMetaNoCache)
 
   frame.restore(function (err, offset) {
     if(err) throw err
@@ -71,9 +65,6 @@ module.exports = function (blocks, frame, codec, file, cache) {
     since: since,
     stream: function (opts) {
       return Looper(createStream(opts))
-    },
-    streamNoCache: function (opts) {
-      return Looper(createStreamNoCache(opts))
     },
 
     //if value is an array of buffers, then treat that as a batch.

--- a/inject.js
+++ b/inject.js
@@ -30,34 +30,31 @@ module.exports = function (blocks, frame, codec, file, cache) {
   })
 
   function getMeta (offset, cb) {
-    return getMetaHelper(offset, true, cb)
+    var data = cache.get(offset)
+    if (data) {
+      cb(null, data.value, data.prev, data.next)
+    }
+    else {
+      frame.getMeta(offset, function (err, value, prev, next) {
+        if(err) return cb(err)
+
+        var data = {
+          value: codec.decode(value),
+          prev: prev,
+          next: next
+        }
+
+        cache.set(offset, data)
+        cb(null, data.value, data.prev, data.next)
+      })
+    }
   }
 
   function getMetaNoCache (offset, cb) {
-    return getMetaHelper(offset, false, cb)
-  }
-
-  function getMetaHelper (offset, useCache, cb) {
-    if (useCache) {
-      var data = cache.get(offset)
-      if (data) {
-        cb(null, data.value, data.prev, data.next)
-        return
-      }
-    }
-
     frame.getMeta(offset, function (err, value, prev, next) {
       if(err) return cb(err)
 
-      var data = {
-        value: codec.decode(value),
-        prev: prev,
-        next: next
-      }
-
-      if (useCache)
-        cache.set(offset, data)
-      cb(null, data.value, data.prev, data.next)
+      cb(null, codec.decode(value), prev, next)
     })
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "resolved": "https://registry.npmjs.org/aligned-block-file/-/aligned-block-file-1.1.2.tgz",
       "integrity": "sha1-SpFo1f7+Xi9SWUncVaSqCZA7MtQ=",
       "requires": {
-        "hashlru": "2.2.0",
-        "int53": "0.2.4",
-        "mkdirp": "0.5.1",
+        "hashlru": "^2.1.0",
+        "int53": "^0.2.4",
+        "mkdirp": "^0.5.1",
         "obv": "0.0.0",
-        "uint48be": "1.0.2"
+        "uint48be": "^1.0.1"
       },
       "dependencies": {
         "obv": {
@@ -24,62 +24,69 @@
       }
     },
     "append-batch": {
-      "version": "https://registry.npmjs.org/append-batch/-/append-batch-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/append-batch/-/append-batch-0.0.1.tgz",
       "integrity": "sha1-kiSFjlVpl8zAfxHx7poShTKqDSU="
     },
     "bench-flumelog": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bench-flumelog/-/bench-flumelog-1.0.1.tgz",
-      "integrity": "sha1-6S99t1VwLMZRQyJM7O6dH+Fp4dQ=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bench-flumelog/-/bench-flumelog-1.1.0.tgz",
+      "integrity": "sha512-I5Rq+vvMFZM5we24Yn6OeZxDUbivvrWlPB5aWNaKZuOdGXe3JRCwMQ+eTorf/cb3Bh894DagpQJJY69w2g4apA==",
       "dev": true,
       "requires": {
-        "pull-paramap": "1.2.2",
-        "pull-stream": "3.6.0"
+        "pull-paramap": "^1.2.1",
+        "pull-stream": "^3.5.0"
       }
     },
     "concat-map": {
-      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "deep-equal": {
-      "version": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
     "define-properties": {
-      "version": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-        "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "defined": {
-      "version": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
     "es-abstract": {
-      "version": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.5.1.tgz",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.5.1.tgz",
       "integrity": "sha1-8L+Wvqdha7lAvOpPUn4x+y7h8io=",
       "dev": true,
       "requires": {
-        "es-to-primitive": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-        "is-callable": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-        "is-regex": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.0",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.3"
       }
     },
     "es-to-primitive": {
-      "version": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-        "is-date-object": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-        "is-symbol": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "explain-error": {
@@ -93,7 +100,7 @@
       "integrity": "sha1-Ns4Gq+Lg4BxE3WnyoWUwWiMgZJs=",
       "dev": true,
       "requires": {
-        "level-codec": "6.2.0"
+        "level-codec": "^6.2.0"
       }
     },
     "for-each": {
@@ -102,30 +109,34 @@
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
       "dev": true,
       "requires": {
-        "is-function": "1.0.1"
+        "is-function": "~1.0.0"
       }
     },
     "foreach": {
-      "version": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
     "fs.realpath": {
-      "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "function-bind": {
-      "version": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
       "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
       "dev": true
     },
     "has": {
-      "version": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+        "function-bind": "^1.0.2"
       }
     },
     "hashlru": {
@@ -140,16 +151,18 @@
       "dev": true
     },
     "inflight": {
-      "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
-      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
@@ -164,17 +177,19 @@
       "integrity": "sha1-besjBJ3YfL4L7MAZCh7OBHedAtM=",
       "dev": true,
       "requires": {
-        "infer-partial-order": "0.1.1",
-        "rng": "0.2.2"
+        "infer-partial-order": "~0.1.1",
+        "rng": "~0.2.2"
       }
     },
     "is-callable": {
-      "version": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
       "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
       "dev": true
     },
     "is-date-object": {
-      "version": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
@@ -185,12 +200,14 @@
       "dev": true
     },
     "is-regex": {
-      "version": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz",
       "integrity": "sha1-DVUYK9358v3ieCIK7Dp1ZCyQhjc=",
       "dev": true
     },
     "is-symbol": {
-      "version": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
       "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
@@ -226,7 +243,8 @@
       }
     },
     "object-keys": {
-      "version": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true
     },
@@ -236,15 +254,17 @@
       "integrity": "sha1-yyNhBjQVNvDaxIFeBnCCIcrX+14="
     },
     "once": {
-      "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
-      "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -261,25 +281,13 @@
       "dev": true
     },
     "pull-cursor": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/pull-cursor/-/pull-cursor-2.1.3.tgz",
-      "integrity": "sha1-Ah6X19I9eK9mrda4wcF/1v2xK2w=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pull-cursor/-/pull-cursor-3.0.0.tgz",
+      "integrity": "sha512-95lZVSF2eSEdOmUtlOBaD9p5YOvlYeCr5FBv2ySqcj/4rpaXI6d8OH+zPHHjKAf58R8QXJRZuyfHkcCX8TZbAg==",
       "requires": {
-        "looper": "4.0.0",
-        "ltgt": "2.2.0",
-        "pull-stream": "3.6.0"
-      },
-      "dependencies": {
-        "ltgt": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
-          "integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI="
-        },
-        "pull-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.0.tgz",
-          "integrity": "sha1-WdAzpoFdTjCX1Hw9KxiTqeWKI1E="
-        }
+        "looper": "^4.0.0",
+        "ltgt": "^2.2.0",
+        "pull-stream": "^3.6.0"
       }
     },
     "pull-looper": {
@@ -287,7 +295,7 @@
       "resolved": "https://registry.npmjs.org/pull-looper/-/pull-looper-1.0.0.tgz",
       "integrity": "sha512-djlD60A6NGe5goLdP5pgbqzMEiWmk1bInuAzBp0QOH4vDrVwh05YDz6UP8+pOXveKEk8wHVP+rB2jBrK31QMPA==",
       "requires": {
-        "looper": "4.0.0"
+        "looper": "^4.0.0"
       }
     },
     "pull-paramap": {
@@ -296,14 +304,13 @@
       "integrity": "sha1-UaQZPOnI1yFdla2tReK824STsjo=",
       "dev": true,
       "requires": {
-        "looper": "4.0.0"
+        "looper": "^4.0.0"
       }
     },
     "pull-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.0.tgz",
-      "integrity": "sha1-WdAzpoFdTjCX1Hw9KxiTqeWKI1E=",
-      "dev": true
+      "integrity": "sha1-WdAzpoFdTjCX1Hw9KxiTqeWKI1E="
     },
     "pull-write": {
       "version": "1.1.4",
@@ -311,17 +318,18 @@
       "integrity": "sha1-3d6jFJO0j2douEooHQHrO1Mf4Lg=",
       "dev": true,
       "requires": {
-        "looper": "4.0.0",
-        "pull-cat": "1.1.11",
-        "pull-stream": "3.6.0"
+        "looper": "^4.0.0",
+        "pull-cat": "^1.1.11",
+        "pull-stream": "^3.4.5"
       }
     },
     "resumer": {
-      "version": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "dev": true,
       "requires": {
-        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+        "through": "~2.3.4"
       }
     },
     "rng": {
@@ -331,13 +339,14 @@
       "dev": true
     },
     "string.prototype.trim": {
-      "version": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "dev": true,
       "requires": {
-        "define-properties": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-        "es-abstract": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.5.1.tgz",
-        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
       }
     },
     "tape": {
@@ -346,19 +355,19 @@
       "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
       "dev": true,
       "requires": {
-        "deep-equal": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-        "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-        "for-each": "0.3.2",
-        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-        "glob": "7.1.2",
-        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "minimist": "1.2.0",
-        "object-inspect": "1.3.0",
-        "resolve": "1.4.0",
-        "resumer": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
-        "string.prototype.trim": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
-        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+        "deep-equal": "~1.0.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.2",
+        "function-bind": "~1.1.0",
+        "glob": "~7.1.2",
+        "has": "~1.0.1",
+        "inherits": "~2.0.3",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.3.0",
+        "resolve": "~1.4.0",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.1.2",
+        "through": "~2.3.8"
       },
       "dependencies": {
         "balanced-match": {
@@ -373,8 +382,8 @@
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
           }
         },
         "glob": {
@@ -383,12 +392,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "minimatch": "3.0.4",
-            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -397,7 +406,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -418,7 +427,7 @@
           "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
           "dev": true,
           "requires": {
-            "path-parse": "1.0.5"
+            "path-parse": "^1.0.5"
           }
         }
       }
@@ -430,8 +439,8 @@
       "dev": true,
       "requires": {
         "pull-spec": "0.0.1",
-        "pull-stream": "3.6.0",
-        "tape": "4.8.0"
+        "pull-stream": "^3.5.0",
+        "tape": "^4.6.2"
       },
       "dependencies": {
         "pull-spec": {
@@ -443,7 +452,8 @@
       }
     },
     "through": {
-      "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -453,7 +463,8 @@
       "integrity": "sha1-C+paZClTtQLP+MNGnQjtWrVDyPY="
     },
     "wrappy": {
-      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     }

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
     "looper": "^4.0.0",
     "ltgt": "^2.1.3",
     "obv": "0.0.1",
-    "pull-cursor": "^2.1.2",
+    "pull-cursor": "^3.0.0",
     "pull-looper": "^1.0.0",
     "uint48be": "^1.0.1"
   },
   "devDependencies": {
-    "bench-flumelog": "^1.1.0",
+    "bench-flumelog": "^1.2.0",
     "flumecodec": "0.0.0",
     "interleavings": "^0.3.1",
     "pull-paramap": "^1.2.0",


### PR DESCRIPTION
When doing large reads the overhead in a cache in the getMeta function can be quite substantial (15%). Also if I know that I'm going to do a lot of reads that I will not need again, there is no reason to blow the cache for everyone else. 

I think it would be a good idea to use it [here](https://github.com/flumedb/flumedb/blob/master/index.js#L83) so that indexing is faster.