### PR TITLE
Faster json parse. buffer.tostring is faster than feeding it buffer directly

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -42,7 +42,7 @@ module.exports = function (blocks, frame, codec, file, cache) {
       if(err) return cb(err)
 
       var data = {
-        value: codec.decode(value),
+        value: codec.decode(value.toString()),
         prev: prev,
         next: next
       }


### PR DESCRIPTION
See https://github.com/arj03/test-json-parse