### PR TITLE
Document block size

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ var log = OffsetLog('/data/log', {
 })
 ```
 
+## Block size
+
+The default 16kb is a good compromise between single reader and
+multiple readers performance. If you mostly read from the database
+with a single reader it might be a good idea to increase it to
+something like 256kb. Be sure to check out bench.js on your system.
+
 ## legacy
 
 if you used `flumelog-offset` before 3, and want to read your old

--- a/bench.js
+++ b/bench.js
@@ -3,7 +3,7 @@ var codec = require('flumecodec')
 
 require('bench-flumelog')(function () {
   return FlumeLog('/tmp/bench-flumelog-offset' + Date.now(), {
-    blockSize: 1024*4,
+    blockSize: 1024*16,
     codec: codec.json
   })
 })


### PR DESCRIPTION
I also changed the block size parameter in benchmark as that is the default and I don't want to give up the wrong impression (worse performance).