### PR TITLE
Allow asynchronous codecs

### DIFF
--- a/test/async.js
+++ b/test/async.js
@@ -1,0 +1,39 @@
+var pull = require('pull-stream')
+var create = require('../')
+var testLog = require('test-flumelog')
+
+function test(name, opts, cb) {
+  testLog(function () {
+    return create('/tmp/test_flumelog-offset_'+Date.now(), Object.assign({
+      blockSize: 1024,
+      codec: {
+        encode: function (v) {
+          return new Promise(function (resolve, reject) {
+            setTimeout(function() {
+              resolve(Buffer(JSON.stringify(v)))
+            }, Math.random() * 100)
+          })
+        },
+        decode: function (v) {
+          return new Promise(function (resolve, reject) {
+            setTimeout(function() {
+              resolve(JSON.parse(v))
+            }, Math.random() * 100)
+          })
+        },
+        buffer: false
+      }
+    }, opts))
+  }, function () {
+    console.log(name + ' done')
+    cb()
+  })
+}
+
+pull(
+  pull.values([32, 48, 53]),
+  pull.asyncMap( function(bits, cb) {
+    test(bits + 'bit', {offsetCodec: bits}, cb)
+  }),
+  pull.drain()
+)


### PR DESCRIPTION
This resolves #13 by wrapping codecs in `Promise.resolve` or `Promise.all` for batch operations, and adds an async test which is just the `flumelog.js` test with `setTimeout`. This shouldn't have any effect on synchronous codecs.

I don't think we're currently handling codec errors, so I've left `reject()` unused, but if there's an elegant way to handle promise rejections I'd be happy to implement it.