### PR TITLE
Respect buffer option in codec and return buffer

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -42,7 +42,7 @@ module.exports = function (blocks, frame, codec, file, cache) {
       if(err) return cb(err)
 
       var data = {
-        value: codec.decode(value.toString()),
+        value: codec.buffer ? codec.decode(value) : codec.decode(value.toString()),
         prev: prev,
         next: next
       }


### PR DESCRIPTION
We should respect buffer option in codec for what we want to return. This allows us to use something that works faster on buffer directly ;-)