### PR TITLE
Export `methods` property for `del()` method

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -123,6 +123,9 @@ module.exports = function (blocks, frame, codec, file, cache) {
         })
       )).catch((err) => cb(err))
       .then(() => cb(null))
+    },
+    methods: {
+      del: 'async'
     }
   }
 }


### PR DESCRIPTION
As discussed with @dominictarr, this adds a property to the flumelog that specifies any non-standard methods so that they can be passed through to flumedb.