### PR TITLE
Fix bug where `opts = { seqs: true }`

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -69,15 +69,11 @@ module.exports = function (blocks, frame, codec, file, cache) {
       return pull(
         Looper(createStream(opts)),
         filter(item => {
-          let value
-
           if (opts && opts.seqs === false) {
-            value = item
+            return isNotDeleted(item)
           } else {
-            value = { item }
+            return isNotDeleted(item.value)
           }
-
-          return isNotDeleted(value)
         })
       )
     },

--- a/test/simple.js
+++ b/test/simple.js
@@ -87,6 +87,18 @@ tape('stream', function (t) {
 
 })
 
+tape('stream with options', function (t) {
+  pull(
+    db.stream({min: 0, seqs: true}),
+    pull.collect(function (err, ary) {
+      if(err) throw err
+
+      t.deepEqual(ary.map(item => String(item.value)), ['hello offset db'])
+      t.end()
+    })
+  )
+})
+
 tape('live', function (t) {
   t.deepEqual(live.map(String), ['hello world', 'hello offset db'])
   t.end()


### PR DESCRIPTION
Previously the code that took care of filtering out deleted items (empty
buffers) just checked whether the item was an empty buffer, but that
doesn't account for the case where `{ seqs: true }` and the value is
actually exposed in `{ value }`.

Resolves #18 